### PR TITLE
Update photo ring strokes to white

### DIFF
--- a/index.html
+++ b/index.html
@@ -242,10 +242,10 @@
       <div class="photo-container">
         <div class="photo-ring">
           <svg class="rotating-ring" viewBox="0 0 160 160">
-            <circle cx="80" cy="80" r="76" fill="none" stroke="#c8e6c9" stroke-width="3" stroke-dasharray="0 8" stroke-linecap="round"/>
+            <circle cx="80" cy="80" r="76" fill="none" stroke="#ffffff" stroke-width="3" stroke-dasharray="0 8" stroke-linecap="round"/>
           </svg>
           <svg class="static-ring" viewBox="0 0 160 160">
-            <circle cx="80" cy="80" r="76" fill="none" stroke="#c8e6c9" stroke-width="3" stroke-dasharray="20 20" stroke-linecap="round"/>
+            <circle cx="80" cy="80" r="76" fill="none" stroke="#ffffff" stroke-width="3" stroke-dasharray="20 20" stroke-linecap="round"/>
           </svg>
           <div class="photo-wrapper" id="photoWrapper">
             <img id="profileImage" src="https://picsum.photos/150" alt="Profile" />


### PR DESCRIPTION
### Motivation

- Make the photo ring's moving and non-moving elements (dots and lines) white for consistent appearance and better contrast against the background.

### Description

- Changed the inline SVG circle `stroke` color for the rotating ring in `index.html` from `#c8e6c9` to `#ffffff`.
- Changed the inline SVG circle `stroke` color for the static ring in `index.html` from `#c8e6c9` to `#ffffff`.
- No other markup or behavior was altered.

### Testing

- Launched a local dev server with `python -m http.server 8000` which started successfully.
- Captured a visual check screenshot using a Playwright script which produced `artifacts/ring-white.png` successfully.
- No unit tests or linter runs were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fcbdd9dec8333b01172ab5b673576)